### PR TITLE
changed Resolve Asset Source 'require' to use actual path to resource

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -8,7 +8,7 @@ var {
     NativeModules: { UIManager, CrosswalkWebViewManager: { JSNavigationScheme } }
 } = ReactNative;
 
-var resolveAssetSource = require('resolveAssetSource')
+var resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSource')
 
 var WEBVIEW_REF = 'crosswalkWebView';
 


### PR DESCRIPTION
- it was only `require('resolveAssetSource')`, which was causing errors in some cases
