### PR TITLE
Fixing goBack, goForward and reload

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -52,7 +52,7 @@ var CrosswalkWebView = React.createClass({
         );
     },
     getWebViewHandle () {
-        return React.findNodeHandle(this.refs[WEBVIEW_REF]);
+        return ReactNative.findNodeHandle(this.refs[WEBVIEW_REF]);
     },
     onNavigationStateChange (event) {
         var { onNavigationStateChange } = this.props;
@@ -69,21 +69,21 @@ var CrosswalkWebView = React.createClass({
     goBack () {
         UIManager.dispatchViewManagerCommand(
             this.getWebViewHandle(),
-            UIManager.NativeCrosswalkWebView.Commands.goBack,
+            UIManager.CrosswalkWebView.Commands.goBack,
             null
         );
     },
     goForward () {
         UIManager.dispatchViewManagerCommand(
             this.getWebViewHandle(),
-            UIManager.NativeCrosswalkWebView.Commands.goForward,
+            UIManager.CrosswalkWebView.Commands.goForward,
             null
         );
     },
     reload () {
         UIManager.dispatchViewManagerCommand(
             this.getWebViewHandle(),
-            UIManager.NativeCrosswalkWebView.Commands.reload,
+            UIManager.CrosswalkWebView.Commands.reload,
             null
         );
     }


### PR DESCRIPTION
Copying the fix from here https://github.com/ruqqq/react-native-webview-crosswalk/commit/71fb00efb50dc10de440941c03e1949e2165bb1e and changing `React.findNodeHandle` to `ReactNative.findNodeHandle` as mentioned here http://stackoverflow.com/a/37202868/5555528
