### PR TITLE
Upgrade to Crosswalk 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Crosswalk's WebView for React Native on Android.
 ```shell
 npm install react-native-webview-crosswalk --save
 mkdir android/app/libs
-cp node_modules/react-native-webview-crosswalk/libs/xwalk_core_library-18.48.477.13.aar android/app/libs/
+cp node_modules/react-native-webview-crosswalk/libs/xwalk_core_library-22.52.561.4.aar android/app/libs/
 ```
 
 ### Include module in your Android project
@@ -59,13 +59,13 @@ allprojects {
 ...
 dependencies {
   ...
-  compile (name: "xwalk_core_library-18.48.477.13", ext: "aar")    // <--- add this line
+  compile (name: "xwalk_core_library-22.52.561.4", ext: "aar")     // <--- add this line
   compile project(':CrosswalkWebView')                             // <--- add this line
 }
 ```
 * Register package :
 
-If [0.1.0](https://github.com/jordansexton/react-native-webview-crosswalk/releases/tag/v0.1.0) or [0.2.0](https://github.com/jordansexton/react-native-webview-crosswalk/releases/tag/v0.2.0)+ used add code into MainActivity.java 
+If [0.1.0](https://github.com/jordansexton/react-native-webview-crosswalk/releases/tag/v0.1.0) or [0.2.0](https://github.com/jordansexton/react-native-webview-crosswalk/releases/tag/v0.2.0)+ used add code into MainActivity.java
 
 ```java
 import com.jordansexton.react.crosswalk.webview.CrosswalkWebViewPackage;    // <--- add this line

--- a/build.gradle
+++ b/build.gradle
@@ -23,5 +23,5 @@ repositories {
 
 dependencies {
     compile "com.facebook.react:react-native:+"
-    compile (name: "xwalk_core_library-18.48.477.13", ext: "aar")
+    compile (name: "xwalk_core_library-22.52.561.4", ext: "aar")
 }

--- a/get_library.js
+++ b/get_library.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var version = '18.48.477.13';
+var version = '22.52.561.4';
 var beta    = '';
 
 var exec = require('child_process').exec;

--- a/get_library.js
+++ b/get_library.js
@@ -8,36 +8,14 @@ var fs   = require('fs');
 var wget = require('node-wget');
 
 function prepareLibrary (filePath) {
-    exec('unzip -j ' + filePath + ' classes.jar', [], (error, stdout, stderr) => {
-        if (error) {
-            console.log(error);
-        }
-        else {
-            exec('zip -d classes.jar javax\\*', [], (error, stdout, stderr) => {
-                if (error) {
-                    console.log(error);
-                }
-                else {
-                    exec('zip -ro ' + filePath + ' classes.jar', [], (error, stdout, stderr) => {
-                        if (error) {
-                            console.log(error);
-                        }
-                        else {
-                            fs.unlinkSync('classes.jar');
-                            try {
-                                fs.unlinkSync('./libs/' + filePath);
-                            }
-                            catch (e) {
-                                console.log('No previous file');
-                            }
-                            fs.renameSync(filePath, './libs/' + filePath);
-                            console.log('Library baked');
-                        }
-                    });
-                }
-            });
-        }
-    });
+    try {
+        fs.unlinkSync('./libs/' + filePath);
+    }
+    catch (e) {
+        console.log('No previous file');
+    }
+    fs.renameSync(filePath, './libs/' + filePath);
+    console.log('Library baked');
 }
 
 function handleDownloaded (error, data) {


### PR DESCRIPTION
Cause 18 is pretty old now. Haven't noticed any differences in API. 😄 

This however will kill support for Android 4.0.